### PR TITLE
Fix stuck notes on octave-shifted scale changes

### DIFF
--- a/lib/components/app/devicemanager.lua
+++ b/lib/components/app/devicemanager.lua
@@ -136,12 +136,15 @@ function MIDIDevice:send(data)
                 elseif next.type == 'interrupt_scale' and next.ch == off.ch then
 
                     local foobar = next.scale:quantize_note(off)
-                   
-                    if off.note % 12 ~= foobar.new_note % 12 then
+
+                    -- send an off event any time the resulting note changes
+                    -- regardless of octave. comparing only pitch class left
+                    -- notes hanging when the scale root shifted by an octave.
+                    if off.note ~= foobar.new_note then
                         self.device:send(off)
                         off_sent = true
                     end
-                    
+
                     self.manager:reportEvents(self.id)
                 end
 

--- a/spec/devicemanager_note_handling_spec.lua
+++ b/spec/devicemanager_note_handling_spec.lua
@@ -38,6 +38,20 @@ describe('DeviceManager note handling', function()
     assert.are.equal(60, stub_device.sent[2].note)
   end)
 
+  it('sends note_off when scale interrupt shifts octave', function()
+    local dev = dm:get(1)
+    dev:send{type='note_on', note=60, vel=64, ch=1}
+
+    -- new scale quantizes the same pitch class an octave higher
+    local scale = { quantize_note=function(_, data) return {new_note=data.note+12} end }
+    dev:emit('interrupt', {type='interrupt_scale', scale=scale, ch=1})
+
+    assert.are.equal(2, #stub_device.sent)
+    assert.are.equal('note_on', stub_device.sent[1].type)
+    assert.are.equal('note_off', stub_device.sent[2].type)
+    assert.are.equal(60, stub_device.sent[2].note)
+  end)
+
   it('ends previous note_on when same note_on arrives', function()
     local dev = dm:get(1)
     dev:send{type='note_on', note=62, vel=80, ch=1}


### PR DESCRIPTION
## Summary
- handle scale change interrupt regardless of octave difference
- test that interrupting when pitch class stays the same still sends note_off

## Testing
- `make test` *(fails: busted not found)*

------
https://chatgpt.com/codex/tasks/task_e_688379c77b6c8328a47983446ad21e33