### PR TITLE
Clarify pitch‑class interrupt behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ The included GitHub workflow runs `make lint` and `make test` on every push and 
 make deploy PI_HOST=user@ip-address
 ```
 This syncs the repo to `~/dust/code/Foobar` on the device.
+
+## Documentation
+
+Additional architecture notes and known issues live in the `docs/` folder. See
+[`docs/scale_note_off_issue.md`](docs/scale_note_off_issue.md) for a discussion
+of note-off handling when scales change and how mismatched note values can leave
+notes stuck.

--- a/docs/scale_note_off_issue.md
+++ b/docs/scale_note_off_issue.md
@@ -1,0 +1,83 @@
+# Scale Change Note Off Bug
+
+This document summarizes how note on/off tracking interacts with the `Scale` component and explains
+why notes may remain held when the scale changes between the `note_on` and `note_off` events.
+
+## DeviceManager logic
+
+When a `note_on` event is sent to a MIDI device, `MIDIDevice:send` registers temporary listeners and
+stores a pending `note_off` message:
+
+```
+local off = {
+    type = 'note_off',
+    note_id = data.note_id or data.note,
+    note = data.note,
+    vel  = data.vel,
+    ch   = data.ch,
+}
+if data.new_note then
+    off.note = data.new_note
+end
+```
+
+During an `interrupt_scale` event the manager checks the new scale and compares pitch classes:
+
+```
+local requantized = next.scale:quantize_note(off)
+if off.note % 12 ~= requantized.new_note % 12 then
+    self.device:send(off)
+end
+```
+
+Lines 94‑141 of `devicemanager.lua` implement this logic.
+
+## Intended interrupt behavior
+
+`interrupt_scale` should only terminate notes that are no longer part of the
+active scale. For example, if notes quantized to C major (`C`, `E` and `G`) are
+held when the scale changes to D major, only the `C` notes should be stopped.
+`E` and `G` remain valid in the new scale and must continue sounding until their
+regular `note_off` events arrive.
+
+## Interaction with `Scale:midi_event`
+
+The `Scale` component modifies messages by setting `data.new_note` while leaving `data.note`
+unchanged. Triggered inputs generate `note_off` events using the last played note
+from `Input:midi_trigger` or `clock_trigger`:
+
+```
+local off = { type = 'note_off', note = event.note, vel = event.vel }
+```
+
+When a scale change occurs before this `note_off` is processed, the note is re‑quantized,
+so the hardware receives a different pitch than was originally sounded.
+`MIDIDevice` believes the note was turned off because the original `note` matches
+`note_id`, but the device actually receives `note_off` for the wrong pitch.
+
+## Gaps in the current logic
+
+1. `interrupt_scale` only checks the pitch class (`% 12`). Transposing the scale by an
+   octave keeps the same class and therefore does not trigger an interrupt.
+2. The subsequent `note_off` event still uses the original `note` field, causing
+   the manager to skip sending the stored `off` message even though the output
+   note has changed.
+3. This affects both physical MIDI input and internally generated notes, since
+   they travel through the same `send` pipeline.
+
+### Pitch‑class based interrupts
+
+`interrupt_scale` intentionally checks only the note\'s pitch class because
+scales are defined as collections of classes. A note should keep playing if the
+same class still exists in the new scale, even when the octave changes. The
+pending `off` table is transmitted only when the new scale no longer contains
+that class.
+
+Earlier versions stored the unquantized pitch in `Input.last_note`, so a
+`note_off` was generated for the original key even if quantization changed the
+outgoing note. The device therefore received a different note-off than it had
+played, leaving it stuck on. This affected both physical MIDI and triggered
+notes because they travel through the same pipeline.
+
+`Input.last_note` now stores the quantized pitch, ensuring that internally
+generated note-off events match the note actually sent to the device.

--- a/lib/components/app/devicemanager.lua
+++ b/lib/components/app/devicemanager.lua
@@ -122,6 +122,9 @@ function MIDIDevice:send(data)
 
                 elseif next.type == 'note_off' then
                     if next.ch == off.ch and (next.note == off.note_id or next.note_id and next.note_id == off.note_id) then
+                        if next.note ~= off.note then
+                            self.device:send(off)
+                        end
                         off_sent = true
                     end
 
@@ -135,9 +138,9 @@ function MIDIDevice:send(data)
 
                 elseif next.type == 'interrupt_scale' and next.ch == off.ch then
 
-                    local foobar = next.scale:quantize_note(off)
-                   
-                    if off.note % 12 ~= foobar.new_note % 12 then
+                    local requantized = next.scale:quantize_note(off)
+
+                    if off.note % 12 ~= requantized.new_note % 12 then
                         self.device:send(off)
                         off_sent = true
                     end

--- a/lib/components/track/input.lua
+++ b/lib/components/track/input.lua
@@ -47,12 +47,12 @@ function Input:midi_trigger(data)
             end
 
             event = self:process(event)
-            
-            if self.last_note then
-                self.last_note = event
-            else
-                self.last_note = event
+
+            if event.new_note then
+                event.note = event.new_note
             end
+
+            self.last_note = event
             
             self.track:send_input(event)
         elseif data.type == 'note_off' then
@@ -79,6 +79,9 @@ function Input:clock_trigger(data,process)
     if self.track.step > 0 and App.tick % self.track.step == self.track.reset_tick then
         local event = self:process(data)
         if event then
+            if event.new_note then
+                event.note = event.new_note
+            end
             clock.run(function()
                 self.track:send_input(event)
 

--- a/spec/devicemanager_note_handling_spec.lua
+++ b/spec/devicemanager_note_handling_spec.lua
@@ -38,6 +38,17 @@ describe('DeviceManager note handling', function()
     assert.are.equal(60, stub_device.sent[2].note)
   end)
 
+  it('ignores scale interrupt when pitch class is unchanged', function()
+    local dev = dm:get(1)
+    dev:send{type='note_on', note=60, vel=64, ch=1}
+
+    local scale = { quantize_note=function(_, data) return {new_note=data.note+12} end }
+    dev:emit('interrupt', {type='interrupt_scale', scale=scale, ch=1})
+
+    assert.are.equal(1, #stub_device.sent)
+    assert.are.equal('note_on', stub_device.sent[1].type)
+  end)
+
   it('ends previous note_on when same note_on arrives', function()
     local dev = dm:get(1)
     dev:send{type='note_on', note=62, vel=80, ch=1}


### PR DESCRIPTION
## Summary
- rename temporary `foobar` variable to `requantized`
- test that scale interrupts ignore octave transpositions
- store quantized note in `Input.last_note`
- send pending note-off when note_off is for mismatched pitch
- document note-off fixes for scale changes

## Testing
- `make lint` *(fails: luacheck not found)*
- `make test` *(fails: busted not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853122634483289832455659fdd8fd