### PR TITLE
Refactor sync management and add debug flags for better control

### DIFF
--- a/src/lib/components/mode/bufferseq.lua
+++ b/src/lib/components/mode/bufferseq.lua
@@ -3,6 +3,7 @@ local ModeComponent = require(path_name .. 'components/mode/modecomponent')
 local Grid = require(path_name .. 'grid')
 local UI = require(path_name .. 'ui')
 local Registry = require('Foobar/lib/utilities/registry')
+local flags = require(path_name .. 'utilities/flags')
 
 local BufferSeq = ModeComponent:new()
 BufferSeq.__base = ModeComponent
@@ -302,13 +303,17 @@ function BufferSeq:recalculate_scrub_from_held_pads()
 			self.scrub_start_tick = start_tick
 			self.scrub_end_tick = end_tick
 			if clip then clip:update_scrub(start_tick, end_tick) end
-			print('Scrub recalculated: ' .. start_tick .. '-' .. end_tick)
+			if flags.debug_scrub then
+				print('Scrub recalculated: ' .. start_tick .. '-' .. end_tick)
+			end
 		else
 			-- Queue new scrub action (this will replace any existing pending scrub)
 			if clip then
 				clip:queue_scrub_action(start_tick, end_tick, App.buffer_scrub_mode == 'loop', pad_check_fn)
-				local next_sync_tick = clip:get_next_sync_tick()
-				print('Scrub queued for sync at tick: ' .. next_sync_tick)
+				if flags.debug_scrub then
+					local next_sync_tick = clip:get_next_sync_tick()
+					print('Scrub queued for sync at tick: ' .. next_sync_tick)
+				end
 			end
 		end
 		return
@@ -320,7 +325,9 @@ function BufferSeq:recalculate_scrub_from_held_pads()
 		self.scrub_start_tick = start_tick
 		self.scrub_end_tick = end_tick
 		if clip then clip:update_scrub(start_tick, end_tick) end
-		print('Scrub recalculated: ' .. start_tick .. '-' .. end_tick)
+		if flags.debug_scrub then
+			print('Scrub recalculated: ' .. start_tick .. '-' .. end_tick)
+		end
 	else
 		-- Start new scrub with full range (min to max)
 		-- Save loop boundaries
@@ -334,7 +341,9 @@ function BufferSeq:recalculate_scrub_from_held_pads()
 		-- Start scrub playback
 		if clip then clip:start_scrub(start_tick, end_tick, App.buffer_scrub_mode == 'loop') end
 
-		print('Scrub started: ' .. start_tick .. '-' .. end_tick .. ' (' .. App.buffer_scrub_mode .. ')')
+		if flags.debug_scrub then
+			print('Scrub started: ' .. start_tick .. '-' .. end_tick .. ' (' .. App.buffer_scrub_mode .. ')')
+		end
 	end
 end
 
@@ -347,10 +356,14 @@ function BufferSeq:jump_to_tick(tick)
 	-- If in scrub mode, set scrub_tick; otherwise set clip.tick
 	if clip and clip.scrub_mode then
 		clip.scrub_tick = tick
-		print('Scrub playback jumped to tick: ' .. tick)
+		if flags.debug_scrub then
+			print('Scrub playback jumped to tick: ' .. tick)
+		end
 	elseif clip then
 		clip.tick = tick
-		print('Clip playback jumped to tick: ' .. tick)
+		if flags.debug_clip then
+			print('Clip playback jumped to tick: ' .. tick)
+		end
 	end
 end
 
@@ -366,7 +379,9 @@ function BufferSeq:resync_with_app()
 		-- Convert App.tick to position within loop: (App.tick % buffer_length) + buffer_start
 		clip.tick = ((App.tick - buffer.buffer_start) % buffer.buffer_length) + buffer.buffer_start
 
-		print('Clip playback resynced with app tick: ' .. App.tick .. ' -> clip.tick: ' .. clip.tick)
+		if flags.debug_clip then
+			print('Clip playback resynced with app tick: ' .. App.tick .. ' -> clip.tick: ' .. clip.tick)
+		end
 	end
 end
 
@@ -387,7 +402,9 @@ function BufferSeq:stop_scrub()
 	self.scrub_end_tick = nil
 	self.scrub_saved_buffer_start = nil
 
-	print('Scrub stopped')
+	if flags.debug_scrub then
+		print('Scrub stopped')
+	end
 end
 
 function BufferSeq:grid_event(component, data)
@@ -436,7 +453,9 @@ function BufferSeq:grid_event(component, data)
 		-- Set playback loop and freeze immediately
 		clip:set_playback_loop(loop_start, loop_length)
 		clip:freeze_buffer()
-		print('Loop frozen: ' .. loop_start .. '-' .. loop_end)
+		if flags.debug_clip then
+			print('Loop frozen: ' .. loop_start .. '-' .. loop_end)
+		end
 	end
 
 	-- Handle pad press (start/update scrub)
@@ -897,7 +916,9 @@ function BufferSeq:alt_event(data)
 			-- Freeze immediately
 			clip:set_playback_loop(loop_start, loop_length)
 			clip:freeze_buffer()
-			print('Scrub frozen to loop: ' .. loop_start .. '-' .. self.scrub_end_tick)
+			if flags.debug_scrub then
+				print('Scrub frozen to loop: ' .. loop_start .. '-' .. self.scrub_end_tick)
+			end
 
 			-- Stop scrub mode (playback now comes from frozen_buffer)
 			self:stop_scrub()

--- a/src/lib/components/mode/clipgrid.lua
+++ b/src/lib/components/mode/clipgrid.lua
@@ -3,6 +3,7 @@ local ModeComponent = require('Foobar/lib/components/mode/modecomponent')
 local Grid = require(path_name .. 'grid')
 local SequenceUtils = require(path_name .. 'utilities/sequence_utils')
 local Registry = require(path_name .. 'utilities/registry')
+local flags = require(path_name .. 'utilities/flags')
 
 local ClipGrid = ModeComponent:new()
 
@@ -88,7 +89,9 @@ function ClipGrid:enable_event()
 
 					if elapsed >= self.max_recording_length then
 						-- Max recording length reached: stop and save
-						print('ClipGrid: Max recording length reached for slot ' .. self.recording_slot .. ' (elapsed: ' .. elapsed .. ' ticks)')
+						if flags.debug_clip then
+							print('ClipGrid: Max recording length reached for slot ' .. self.recording_slot .. ' (elapsed: ' .. elapsed .. ' ticks)')
+						end
 						self:stop_recording_and_save(clip, self.recording_slot)
 					end
 				end
@@ -159,28 +162,30 @@ function ClipGrid:queue_recording_start(clip, bank_slot)
 
 	-- Cancel any pending recording
 	if self.recording_pending then
-		clip.sync_action_queue:clear_action()
+		clip.sync_manager:clear('clipgrid_recording')
 		self.recording_pending = nil
 	end
 
 	-- Get sync length from track parameter (respects user's action_sync setting)
 	-- For clip recording, we use the track's action_sync_length parameter for quantization
 	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local current_tick = App.tick or 1
-	-- Use sync_length as the boundary for clip recording quantization
-	local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
-	local boundary = sync_length -- Use sync_length directly for clip recording
 
-	print('ClipGrid: Queue recording start for slot ' .. bank_slot)
-	print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
-	print('  Sync length: ' .. sync_length .. ', boundary: ' .. boundary)
-	print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	if flags.debug_clip then
+		local current_tick = App.tick or 1
+		local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
+		print('ClipGrid: Queue recording start for slot ' .. bank_slot)
+		print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
+		print('  Sync length: ' .. sync_length)
+		print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	end
 
 	-- Create action to start recording
 	local action_fn = function(component, action_data)
-		local exec_tick = App.tick or 1
-		print('ClipGrid: Executing recording start for slot ' .. action_data.bank_slot)
-		print('  Execution App.tick: ' .. exec_tick .. ', buffer.tick: ' .. component.buffer.tick)
+		if flags.debug_clip then
+			local exec_tick = App.tick or 1
+			print('ClipGrid: Executing recording start for slot ' .. action_data.bank_slot)
+			print('  Execution App.tick: ' .. exec_tick .. ', buffer.tick: ' .. component.buffer.tick)
+		end
 		self:start_recording(component, action_data.bank_slot)
 	end
 
@@ -188,15 +193,9 @@ function ClipGrid:queue_recording_start(clip, bank_slot)
 		bank_slot = bank_slot,
 	}
 
-	-- Create a temporary sync action queue with the correct sync_length for clip recording
-	-- The clip's sync_action_queue uses action_sync_length from track parameter
-	local function get_sync_length_fn(component) return sync_length end
-	local temp_queue = SequenceUtils.create_sync_action_queue(clip, get_sync_length_fn)
-	temp_queue:queue_action(action_fn, action_data)
+	-- Queue in the 'clipgrid_recording' slot using SyncManager
+	clip.sync_manager:queue('clipgrid_recording', action_fn, action_data, sync_length)
 	self.recording_pending = { bank_slot = bank_slot }
-
-	-- Store the temp queue so it can execute
-	clip._clipgrid_sync_queue = temp_queue
 end
 
 -- Start recording to a bank slot
@@ -209,19 +208,21 @@ function ClipGrid:start_recording(clip, bank_slot)
 	local app_tick = App.tick or 1
 	local recording_start_tick = app_tick
 
-	-- Verify sync alignment (use track's action_sync_length parameter)
-	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local boundary = sync_length -- Use sync_length directly for clip recording
-	local relative_tick = recording_start_tick - 1
-	local is_aligned = (relative_tick % boundary == 0)
+	if flags.debug_clip then
+		-- Verify sync alignment (use track's action_sync_length parameter)
+		local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
+		local boundary = sync_length
+		local relative_tick = recording_start_tick - 1
+		local is_aligned = (relative_tick % boundary == 0)
 
-	print('ClipGrid: Start recording slot ' .. bank_slot)
-	print('  App.tick: ' .. app_tick .. ', buffer.tick: ' .. clip.buffer.tick)
-	print('  Using recording_start_tick: ' .. recording_start_tick .. ' (from App.tick)')
-	print('  Boundary: ' .. boundary .. ', aligned: ' .. tostring(is_aligned))
-	if not is_aligned then
-		print('  WARNING: App.tick not aligned to sync boundary!')
-		print('  Relative tick: ' .. relative_tick .. ', remainder: ' .. (relative_tick % boundary))
+		print('ClipGrid: Start recording slot ' .. bank_slot)
+		print('  App.tick: ' .. app_tick .. ', buffer.tick: ' .. clip.buffer.tick)
+		print('  Using recording_start_tick: ' .. recording_start_tick .. ' (from App.tick)')
+		print('  Boundary: ' .. boundary .. ', aligned: ' .. tostring(is_aligned))
+		if not is_aligned then
+			print('  WARNING: App.tick not aligned to sync boundary!')
+			print('  Relative tick: ' .. relative_tick .. ', remainder: ' .. (relative_tick % boundary))
+		end
 	end
 
 	-- Align buffer.tick to the sync-aligned App.tick
@@ -232,11 +233,6 @@ function ClipGrid:start_recording(clip, bank_slot)
 	-- This prevents doubling: the clip would play while new input is being recorded
 	-- If user wants overdub, they should record to the same slot that's already playing
 	if clip.current_slot then clip:unload_clip() end
-
-	-- Set loop boundaries for recording
-	-- Start at sync-aligned tick, end at max recording length
-	-- This ensures recording stays within bounds and can be saved correctly
-	local loop_end = recording_start_tick + self.max_recording_length - 1
 
 	-- Store recording state
 	self.recording_slot = bank_slot
@@ -253,24 +249,25 @@ function ClipGrid:queue_recording_stop(clip, bank_slot)
 	if self.recording_slot ~= bank_slot then return end
 
 	-- Get sync length from track parameter (respects user's action_sync setting)
-	-- For clip recording, we use the track's action_sync_length parameter for quantization
 	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local current_tick = App.tick or 1
-	-- Use sync_length as the boundary for clip recording quantization
-	local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
-	local boundary = sync_length -- Use sync_length directly for clip recording
 
-	print('ClipGrid: Queue recording stop for slot ' .. bank_slot)
-	print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
-	print('  Recording started at tick: ' .. (self.recording_start_tick or 'unknown'))
-	print('  Sync length: ' .. sync_length .. ', boundary: ' .. boundary)
-	print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	if flags.debug_clip then
+		local current_tick = App.tick or 1
+		local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
+		print('ClipGrid: Queue recording stop for slot ' .. bank_slot)
+		print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
+		print('  Recording started at tick: ' .. (self.recording_start_tick or 'unknown'))
+		print('  Sync length: ' .. sync_length)
+		print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	end
 
 	-- Create action to stop recording and save
 	local action_fn = function(component, action_data)
-		local exec_tick = App.tick or 1
-		print('ClipGrid: Executing recording stop for slot ' .. action_data.bank_slot)
-		print('  Execution App.tick: ' .. exec_tick .. ', buffer.tick: ' .. component.buffer.tick)
+		if flags.debug_clip then
+			local exec_tick = App.tick or 1
+			print('ClipGrid: Executing recording stop for slot ' .. action_data.bank_slot)
+			print('  Execution App.tick: ' .. exec_tick .. ', buffer.tick: ' .. component.buffer.tick)
+		end
 		self:stop_recording_and_save(component, action_data.bank_slot)
 	end
 
@@ -278,8 +275,8 @@ function ClipGrid:queue_recording_stop(clip, bank_slot)
 		bank_slot = bank_slot,
 	}
 
-	-- Queue the action
-	clip.sync_action_queue:queue_action(action_fn, action_data)
+	-- Queue in the 'clipgrid_recording_stop' slot using SyncManager
+	clip.sync_manager:queue('clipgrid_recording_stop', action_fn, action_data, sync_length)
 end
 
 -- Stop recording and save clip to bank slot
@@ -292,88 +289,58 @@ function ClipGrid:stop_recording_and_save(clip, bank_slot)
 	if not recording_start_tick then return end
 
 	-- Use buffer.tick to get the last tick that was actually recorded
-	-- buffer.tick increments AFTER recording each clock tick, so the last recorded tick is buffer.tick - 1
-	-- We need to use buffer.tick (not App.tick) to ensure we capture all recorded data
 	local buffer_tick = clip.buffer.tick
 	local last_recorded_tick = buffer_tick - 1
-
-	-- Always use last_recorded_tick as the base (not App.tick)
-	-- App.tick points to the next tick to be processed, not the last recorded tick
-	-- Using last_recorded_tick ensures we match the behavior of menu/frozen_buffer saves
-	-- The sync alignment logic below will handle rounding down if needed
 	local loop_end = last_recorded_tick
 
-	-- Get sync length for alignment verification and later sync adjustment
+	-- Get sync length for alignment
 	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local boundary = sync_length -- Use sync_length directly for clip recording
 
-	-- Verify sync alignment
-	local is_aligned = (last_recorded_tick % boundary == 0)
-
-	print('ClipGrid: Stop recording slot ' .. bank_slot)
-	print('  Last recorded tick: ' .. last_recorded_tick .. ' (buffer.tick - 1)')
-	print('  Using loop_end: ' .. loop_end .. ' (sync-aligned from last recorded)')
-	print('  Recording started at: ' .. recording_start_tick)
-	print('  Boundary: ' .. boundary .. ', aligned: ' .. tostring(is_aligned))
-	if not is_aligned then print('  WARNING: loop_end not aligned to sync boundary!') end
+	if flags.debug_clip then
+		local is_aligned = (last_recorded_tick % sync_length == 0)
+		print('ClipGrid: Stop recording slot ' .. bank_slot)
+		print('  Last recorded tick: ' .. last_recorded_tick .. ' (buffer.tick - 1)')
+		print('  Recording started at: ' .. recording_start_tick)
+		print('  Sync length: ' .. sync_length .. ', aligned: ' .. tostring(is_aligned))
+	end
 
 	-- Clamp to max recording length
 	local max_end_tick = recording_start_tick + self.max_recording_length - 1
 	loop_end = math.min(loop_end, max_end_tick)
 
-	-- Ensure we have at least 1 tick of data (minimum clip length)
+	-- Ensure we have at least 1 tick of data
 	if loop_end < recording_start_tick then loop_end = recording_start_tick end
 
-	-- Ensure loop_end doesn't exceed buffer's current loop end (set during recording start)
+	-- Ensure loop_end doesn't exceed buffer's current loop end
 	local buffer_loop_end = clip.buffer.buffer_start + clip.buffer.buffer_length - 1
 	loop_end = math.min(loop_end, buffer_loop_end)
 
-	-- Ensure loop_end creates a clip length that is a multiple of sync_length
-	-- This prevents drift by ensuring the clip loops perfectly
-	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
+	-- Ensure clip length is a multiple of sync_length to prevent drift
 	local raw_length = loop_end - recording_start_tick + 1
 	local sync_units = math.floor(raw_length / sync_length)
 	local remainder = raw_length % sync_length
 
-	-- If there's a remainder, adjust loop_end to make the length a perfect multiple
 	if remainder ~= 0 then
-		-- Round down to the previous sync boundary to ensure perfect alignment
-		-- This might cut off a few ticks, but prevents drift
 		loop_end = recording_start_tick + (sync_units * sync_length) - 1
-		print('ClipGrid: Adjusted loop_end from ' .. (recording_start_tick + raw_length - 1) .. ' to ' .. loop_end .. ' to ensure sync alignment')
+		if flags.debug_clip then
+			print('ClipGrid: Adjusted loop_end to ' .. loop_end .. ' for sync alignment')
+		end
 	end
-	print('STOP AND SAVE--------------------------------')
 
 	-- Save clip to bank
 	local clip_name = string.format('Clip %03d', bank_slot)
 	local success = clip:save_clip_to_bank(bank_slot, recording_start_tick, loop_end, clip_name)
 
 	if success then
-		local clip_length = loop_end - recording_start_tick + 1
-		local expected_bars = clip_length / (App.ppqn * 4) -- 1 bar = 4 beats * App.ppqn ticks
-		local final_sync_units = clip_length / sync_length
-		local final_remainder = clip_length % sync_length
-
-		print('ClipGrid: Saved clip to slot ' .. bank_slot)
-		print('  Tick range: ' .. recording_start_tick .. ' to ' .. loop_end .. ' (inclusive)')
-		print('  Clip length: ' .. clip_length .. ' ticks')
-		print('  Sync length: ' .. sync_length .. ' ticks (action_sync setting)')
-		print('  Expected bars: ' .. string.format('%.2f', expected_bars) .. ' bars')
-		print('  Sync units: ' .. string.format('%.2f', final_sync_units) .. ' units')
-		print('  Remainder: ' .. final_remainder .. ' ticks (should be 0 for perfect sync alignment)')
-		if final_remainder ~= 0 then
-			print('  WARNING: Clip length is NOT a multiple of sync_length! This will cause drift.')
-		else
-			print('  ✓ Clip length is perfectly aligned to sync boundaries')
+		if flags.debug_clip then
+			local clip_length = loop_end - recording_start_tick + 1
+			print('ClipGrid: Saved clip to slot ' .. bank_slot .. ' (' .. clip_length .. ' ticks)')
 		end
 
 		-- Auto-load and play the clip that was just saved
-		-- This ensures playback starts immediately after recording
 		if App.playing then
-			-- Queue playback on next sync tick (or start immediately if already on sync boundary)
 			self:queue_clip_playback(clip, bank_slot)
 		else
-			-- Transport not playing: just load the clip (will play when transport starts)
 			clip:load_clip_from_bank(bank_slot)
 		end
 
@@ -392,29 +359,24 @@ end
 function ClipGrid:queue_clip_playback(clip, bank_slot)
 	if not clip or not clip.clip_bank[bank_slot] then return end
 
-	-- If same clip is already playing, don't queue playback (should use queue_clip_stop instead)
-	if clip.current_slot == bank_slot then
-		-- Already playing this clip: no action needed (caller should use queue_clip_stop)
-		return
-	end
+	-- If same clip is already playing, don't queue playback
+	if clip.current_slot == bank_slot then return end
 
-	-- Get sync length from track parameter (respects user's action_sync setting)
-	-- For clip playback, we use the track's action_sync_length parameter for quantization
+	-- Get sync length from track parameter
 	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local current_tick = App.tick or 1
-	-- Use sync_length as the boundary for clip playback quantization
-	local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
-	local boundary = sync_length -- Use sync_length directly for clip playback
 
-	print('ClipGrid: Queue clip playback for slot ' .. bank_slot)
-	print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
-	print('  Sync length: ' .. sync_length .. ', boundary: ' .. boundary)
-	print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	if flags.debug_clip then
+		local current_tick = App.tick or 1
+		local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
+		print('ClipGrid: Queue clip playback for slot ' .. bank_slot)
+		print('  Current App.tick: ' .. current_tick .. ', sync tick: ' .. next_sync_tick)
+	end
 
 	-- Create action to load and play clip
 	local action_fn = function(component, action_data)
-		local exec_tick = App.tick or 1
-		print('ClipGrid: Executing clip playback for slot ' .. action_data.bank_slot .. ' at App.tick: ' .. exec_tick)
+		if flags.debug_clip then
+			print('ClipGrid: Executing clip playback for slot ' .. action_data.bank_slot .. ' at App.tick: ' .. (App.tick or 1))
+		end
 		component:load_clip_from_bank(action_data.bank_slot)
 	end
 
@@ -422,36 +384,31 @@ function ClipGrid:queue_clip_playback(clip, bank_slot)
 		bank_slot = bank_slot,
 	}
 
-	-- Create a temporary sync action queue with the correct sync_length for clip playback
-	-- The clip's sync_action_queue uses action_sync_length from track parameter
-	local function get_sync_length_fn(component) return sync_length end
-	local temp_queue = SequenceUtils.create_sync_action_queue(clip, get_sync_length_fn)
-	temp_queue:queue_action(action_fn, action_data)
-
-	-- Store the temp queue so it can execute
-	clip._clipgrid_sync_queue = temp_queue
+	-- Queue in the 'clipgrid_playback' slot using SyncManager
+	clip.sync_manager:queue('clipgrid_playback', action_fn, action_data, sync_length)
 end
 
 -- Queue clip stop on next sync tick
 function ClipGrid:queue_clip_stop(clip, bank_slot)
 	if not clip or clip.current_slot ~= bank_slot then return end
 
-	-- Get sync length from track parameter (respects user's action_sync setting)
+	-- Get sync length from track parameter
 	local sync_length = SequenceUtils.get_sync_length(clip.buffer, clip.action_sync_length)
-	local current_tick = App.tick or 1
-	local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
 
-	print('ClipGrid: Queue clip stop for slot ' .. bank_slot)
-	print('  Current App.tick: ' .. current_tick .. ', buffer.tick: ' .. clip.buffer.tick)
-	print('  Sync length: ' .. sync_length)
-	print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	if flags.debug_clip then
+		local current_tick = App.tick or 1
+		local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
+		print('ClipGrid: Queue clip stop for slot ' .. bank_slot)
+		print('  Current App.tick: ' .. current_tick .. ', sync tick: ' .. next_sync_tick)
+	end
 
 	-- Create action to unload clip (stops playback)
 	local action_fn = function(component, action_data)
-		local exec_tick = App.tick or 1
-		print('ClipGrid: Executing clip stop for slot ' .. action_data.bank_slot .. ' at App.tick: ' .. exec_tick)
+		if flags.debug_clip then
+			print('ClipGrid: Executing clip stop for slot ' .. action_data.bank_slot .. ' at App.tick: ' .. (App.tick or 1))
+		end
 		component:unload_clip()
-		-- Emit event so grid can update
+		-- Update grid display
 		if self.set_grid then self:set_grid(component) end
 	end
 
@@ -459,13 +416,8 @@ function ClipGrid:queue_clip_stop(clip, bank_slot)
 		bank_slot = bank_slot,
 	}
 
-	-- Create a temporary sync action queue with the correct sync_length for clip stop
-	local function get_sync_length_fn(component) return sync_length end
-	local temp_queue = SequenceUtils.create_sync_action_queue(clip, get_sync_length_fn)
-	temp_queue:queue_action(action_fn, action_data)
-
-	-- Store the temp queue so it can execute
-	clip._clipgrid_sync_queue = temp_queue
+	-- Queue in the 'clipgrid_stop' slot using SyncManager
+	clip.sync_manager:queue('clipgrid_stop', action_fn, action_data, sync_length)
 end
 
 function ClipGrid:transport_event(clip, data)

--- a/src/lib/components/track/buffer.lua
+++ b/src/lib/components/track/buffer.lua
@@ -5,6 +5,8 @@ local TrackComponent = require('Foobar/lib/components/track/trackcomponent')
 local Registry = require(path_name .. 'utilities/registry')
 local flags = require(path_name .. 'utilities/flags')
 local SequenceUtils = require(path_name .. 'utilities/sequence_utils')
+local TimingConstants = require(path_name .. 'utilities/timing_constants')
+local EventStore = require(path_name .. 'utilities/event_store')
 
 -- Buffer component handles recording of MIDI events only
 -- Separated from Auto and Clip components for clear separation of concerns:
@@ -34,7 +36,7 @@ function Buffer:set(o)
 	-- Buffer's own timing state (independent from Auto)
 	self.tick = o.tick or 0 -- Buffer's recording position in ticks (continuously running)
 	self.buffer_start = o.buffer_start or 1 -- Starting tick of the buffer
-	self.buffer_length = o.buffer_length or (App.ppqn * 4 * 256) -- Static buffer length (64 bars default)
+	self.buffer_length = o.buffer_length or TimingConstants.get_default_buffer_length() -- Static buffer length (64 bars default)
 	self.playing = false
 	self.enabled = true
 
@@ -42,15 +44,22 @@ function Buffer:set(o)
 
 	-- Single buffer architecture: Buffer continuously records, Clip handles playback via frozen_buffer
 	-- Buffer loops back over itself at buffer_start + buffer_length
-	self.buffer = {} -- Single buffer for recording
+	-- EventStore provides efficient range queries and maintains sorted tick index
+	self.store = EventStore.new()
+
+	-- Backward compatibility: self.buffer points to store's internal events table
+	-- This allows existing code to access buffer[tick] directly
+	self.buffer = self.store.events
 
 	-- Migrate existing buffer data if present (backward compatibility)
 	-- This handles migration from old double-buffer structure
 	if o.buffer then
-		self.buffer = o.buffer
+		self.store:from_sparse_table(o.buffer)
+		self.buffer = self.store.events
 	elseif o.buffer_write then
 		-- Migrate from old buffer_write
-		self.buffer = o.buffer_write
+		self.store:from_sparse_table(o.buffer_write)
+		self.buffer = self.store.events
 	end
 
 	-- Overwrite mode tracking: tracks which steps have been cleared in current loop iteration
@@ -83,19 +92,17 @@ function Buffer:record_buffer(midi_event, event_tick)
 	local record_start = flags.buffer_timing_stats and util.time() or nil
 
 	-- Determine the recording tick
-
 	local recording_tick = self.tick
 
 	-- Wrap tick within the buffer boundaries
 	local tick = self:wrap_tick(recording_tick)
-	-- Initialize buffer table for this tick if needed
-	if not self.buffer[tick] then self.buffer[tick] = {} end
 
 	midi_event.buffer_sent = nil
 	midi_event.tick = recording_tick
 	midi_event.external_tick = App.external_tick
-	-- Store the event (multiple events can exist at same tick)
-	table.insert(self.buffer[tick], midi_event)
+
+	-- Store the event using EventStore (maintains sorted tick index)
+	self.store:insert(tick, midi_event)
 
 	-- Record timing (conditional on flag)
 	if flags.buffer_timing_stats and record_start then
@@ -106,9 +113,7 @@ function Buffer:record_buffer(midi_event, event_tick)
 end
 
 -- Clear buffer events for a single tick (used for overwrite mode)
-function Buffer:clear_buffer_tick(tick)
-	if self.buffer[tick] then self.buffer[tick] = nil end
-end
+function Buffer:clear_buffer_tick(tick) self.store:delete(tick) end
 
 -- Clear buffer events for a tick range
 -- Used for overwrite mode when entering a new step
@@ -119,27 +124,23 @@ function Buffer:clear_buffer_range(start_tick, end_tick)
 
 	-- Handle wrap-around case
 	if start_tick <= end_tick then
-		-- Normal range (no wrap)
-		for tick = start_tick, end_tick do
-			if self.buffer[tick] then self.buffer[tick] = nil end
-		end
+		-- Normal range (no wrap) - delete_range_inclusive handles both inclusive ends
+		self.store:delete_range_inclusive(start_tick, end_tick)
 	else
 		-- Wrap-around case (start > end)
 		-- Clear from start to buffer_end
 		local buffer_end = self.buffer_start + self.buffer_length - 1
-		for tick = start_tick, buffer_end do
-			if self.buffer[tick] then self.buffer[tick] = nil end
-		end
+		self.store:delete_range_inclusive(start_tick, buffer_end)
 		-- Clear from buffer_start to end
-		for tick = self.buffer_start, end_tick do
-			if self.buffer[tick] then self.buffer[tick] = nil end
-		end
+		self.store:delete_range_inclusive(self.buffer_start, end_tick)
 	end
 end
 
 -- Clear entire buffer
 function Buffer:clear_buffer()
-	self.buffer = {}
+	self.store:clear()
+	-- Update buffer reference to new events table
+	self.buffer = self.store.events
 	self:emit('clear_buffer')
 end
 
@@ -184,14 +185,12 @@ function Buffer:transport_event(data)
 
 		-- Always overwrite: when entering a new step, clear that step
 		-- Overdub behavior is achieved through monitor settings (IN = input always flows, including clip playback)
-		-- Use a simple step size (8 ticks) for overwrite clearing
-		local step_size = 8 -- Hardcoded step size for overwrite clearing
-		local step_index = math.floor((next_tick - self.buffer_start) / step_size) + 1
+		local step_size = TimingConstants.DEFAULT_STEP_SIZE
+		local step_index = TimingConstants.tick_to_buffer_step(next_tick, self.buffer_start, step_size)
 
 		-- Clear the step if we haven't cleared it in this loop iteration
 		if not self.overwrite_cleared_steps[step_index] then
-			local step_start = self.buffer_start + (step_index - 1) * step_size
-			local step_end = math.min(step_start + step_size - 1, buffer_end)
+			local step_start, step_end = TimingConstants.buffer_step_to_tick_range(step_index, self.buffer_start, buffer_end, step_size)
 			self:clear_buffer_range(step_start, step_end)
 			self.overwrite_cleared_steps[step_index] = true
 		end
@@ -206,6 +205,62 @@ function Buffer:transport_event(data)
 
 	return data
 end
+
+-- ============================================================================
+-- EVENT STORE ACCESS METHODS
+-- These methods expose the EventStore's efficient range query capabilities
+-- ============================================================================
+
+-- Get events in a tick range (shallow copy)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return table Sparse table of tick -> events
+function Buffer:get_range(start_tick, end_tick) return self.store:get_range(start_tick, end_tick) end
+
+-- Get events in a tick range as sorted array
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return table Array of {tick=number, events=table}
+function Buffer:get_range_array(start_tick, end_tick) return self.store:get_range_array(start_tick, end_tick) end
+
+-- Iterate over events in a range (memory efficient - no copy)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return function Iterator returning tick, events
+function Buffer:iter_range(start_tick, end_tick) return self.store:iter_range(start_tick, end_tick) end
+
+-- Get events at a specific tick
+-- @param tick number The tick position
+-- @return table|nil Array of events or nil
+function Buffer:get_events(tick) return self.store:get(tick) end
+
+-- Check if tick has events
+-- @param tick number The tick position
+-- @return boolean True if events exist
+function Buffer:has_events(tick) return self.store:has(tick) end
+
+-- Get count of ticks with events
+-- @return number Count of ticks
+function Buffer:tick_count() return self.store:count() end
+
+-- Get total event count
+-- @return number Total number of events
+function Buffer:event_count() return self.store:event_count() end
+
+-- Get first tick with events
+-- @return number|nil First tick or nil
+function Buffer:first_tick() return self.store:first_tick() end
+
+-- Get last tick with events
+-- @return number|nil Last tick or nil
+function Buffer:last_tick() return self.store:last_tick() end
+
+-- Copy events from a range (for clip saving, scrub buffer, etc.)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @param tick_offset number Optional offset to apply to ticks (default 0)
+-- @return EventStore New EventStore with copied events
+function Buffer:copy_range(start_tick, end_tick, tick_offset) return self.store:copy_range(start_tick, end_tick, tick_offset) end
 
 -- Add diagnostic function to print stats
 function Buffer:print_timing()

--- a/src/lib/components/track/clip.lua
+++ b/src/lib/components/track/clip.lua
@@ -5,6 +5,8 @@ local Registry = require(path_name .. 'utilities/registry')
 local flags = require(path_name .. 'utilities/flags')
 local Persistence = require(path_name .. 'utilities/persistence')
 local SequenceUtils = require(path_name .. 'utilities/sequence_utils')
+local TimingConstants = require(path_name .. 'utilities/timing_constants')
+local SyncManager = require(path_name .. 'utilities/sync_manager')
 
 -- Clip component handles playback of MIDI events from buffer
 -- Separated from Buffer component for clear separation of concerns:
@@ -40,7 +42,6 @@ function Clip:set(o)
 	self.playback_start = nil -- Playback loop start (independent of buffer.buffer_start)
 	self.playback_length = nil -- Playback loop length
 	self.last_frozen_step_index = nil -- Track step transitions for incremental updates
-	local step_size = 8 -- Hardcoded step size for incremental updates
 
 	-- Scrub playback state
 	self.scrub_mode = false
@@ -54,10 +55,11 @@ function Clip:set(o)
 	-- Action sync settings (will be read from buffer after buffer is loaded)
 	self.action_sync_length = nil
 
-	-- Sync action queue for scrub actions (uses scrub_length, not action_sync)
-	-- Scrub sync queue is created dynamically when scrub is queued (based on scrub range length)
-	self.scrub_sync_queue = nil -- Created dynamically in queue_scrub_action
-	self.sync_action_queue = SequenceUtils.create_sync_action_queue(self, function(component) return SequenceUtils.get_sync_length(component.buffer, component.action_sync_length) end)
+	-- Unified sync manager replaces multiple sync queues
+	-- Provides named slots: 'scrub', 'clip', 'general', etc.
+	self.sync_manager = SyncManager.new(self, function(component)
+		return SequenceUtils.get_sync_length(component.buffer, component.action_sync_length)
+	end)
 
 	-- Clip bank management
 	self.clip_bank = {} -- 16 slots: {[1-16] = nil or {filename, name, buffer, playback_settings}}
@@ -156,22 +158,13 @@ function Clip:queue_scrub_action(start_tick, end_tick, loop_mode, pad_check_fn)
 	-- Calculate scrub length for sync quantization
 	local scrub_length = end_tick - start_tick + 1
 
-	-- Create scrub-specific sync queue if it doesn't exist or scrub length changed
-	-- This queue uses scrub_length as the sync boundary (not action_sync_length)
-	if not self.scrub_sync_queue or self.scrub_sync_queue.scrub_length ~= scrub_length then
-		local function get_scrub_sync_length_fn(component)
-			-- Return the scrub_length for this specific scrub range
-			return component.scrub_sync_queue.scrub_length
-		end
-		self.scrub_sync_queue = SequenceUtils.create_sync_action_queue(self, get_scrub_sync_length_fn)
-		self.scrub_sync_queue.scrub_length = scrub_length -- Store scrub_length in queue for sync calculation
-	end
-
 	local action_fn = function(component, action_data)
 		-- Check if pad is still held before executing
 		if action_data.pad_check_fn and action_data.pad_check_fn() then
 			component:start_scrub(action_data.start_tick, action_data.end_tick, action_data.loop_mode)
-			print('Scrub started (synced to ' .. scrub_length .. ' ticks): ' .. action_data.start_tick .. '-' .. action_data.end_tick)
+			if flags.debug_scrub then
+				print('Scrub started (synced to ' .. action_data.scrub_length .. ' ticks): ' .. action_data.start_tick .. '-' .. action_data.end_tick)
+			end
 			-- Emit event so bufferseq can update its state
 			component:emit('scrub_started', {
 				start_tick = action_data.start_tick,
@@ -180,7 +173,9 @@ function Clip:queue_scrub_action(start_tick, end_tick, loop_mode, pad_check_fn)
 		else
 			component:stop_scrub()
 			-- Pad was released, cancel the action
-			print('Scrub cancelled: pad no longer held')
+			if flags.debug_scrub then
+				print('Scrub cancelled: pad no longer held')
+			end
 			component:emit('scrub_stopped', {
 				start_tick = action_data.start_tick,
 				end_tick = action_data.end_tick,
@@ -193,27 +188,26 @@ function Clip:queue_scrub_action(start_tick, end_tick, loop_mode, pad_check_fn)
 		end_tick = end_tick,
 		loop_mode = loop_mode,
 		pad_check_fn = pad_check_fn,
+		scrub_length = scrub_length,
 	}
 
-	self.scrub_sync_queue:queue_action(action_fn, action_data)
+	-- Queue in the 'scrub' slot with scrub_length as sync boundary
+	self.sync_manager:queue('scrub', action_fn, action_data, scrub_length)
 end
 
 -- Clear pending scrub action (called when pad is released)
-function Clip:clear_pending_scrub()
-	if self.scrub_sync_queue then self.scrub_sync_queue:clear_action() end
-end
+function Clip:clear_pending_scrub() self.sync_manager:clear('scrub') end
 
 -- Incrementally update frozen_buffer by copying one step from buffer
 -- Called on step transitions to maintain frozen snapshot efficiently
 function Clip:update_frozen_step(step_index)
 	if not self.buffer or not self.playback_start or not self.playback_length then return end
 
-	local step_size = 8 -- Hardcoded step size for incremental updates
-	local step_start = self.playback_start + (step_index - 1) * step_size
-	local step_end = math.min(step_start + step_size - 1, self.playback_start + self.playback_length - 1)
+	local step_size = TimingConstants.DEFAULT_STEP_SIZE
+	local loop_end = self.playback_start + self.playback_length - 1
+	local step_start, step_end = TimingConstants.buffer_step_to_tick_range(step_index, self.playback_start, loop_end, step_size)
 
 	-- Clamp to playback loop boundaries
-	local loop_end = self.playback_start + self.playback_length - 1
 	step_start = math.max(step_start, self.playback_start)
 	step_end = math.min(step_end, loop_end)
 
@@ -251,7 +245,9 @@ function Clip:freeze_buffer()
 
 	self.buffer_frozen = true
 	self.frozen_tick = self.buffer.tick
-	print('Clip: Buffer frozen at playback range ' .. self.playback_start .. '-' .. loop_end)
+	if flags.debug_clip then
+		print('Clip: Buffer frozen at playback range ' .. self.playback_start .. '-' .. loop_end)
+	end
 
 	-- Kill notes when freezing buffer to prevent stuck notes from previous playback
 	if App.playing then self:kill_notes() end
@@ -262,6 +258,7 @@ end
 
 -- Unfreeze the buffer (resume updating frozen_buffer incrementally)
 function Clip:unfreeze_buffer()
+	local was_frozen = self.buffer_frozen
 	self.buffer_frozen = false
 	self.frozen_tick = nil
 	-- Clear frozen buffer and reset playback loop boundaries
@@ -270,7 +267,6 @@ function Clip:unfreeze_buffer()
 	self.playback_length = nil
 	-- Reset step tracking to resume incremental updates
 	self.last_frozen_step_index = nil
-	print('Clip: Buffer unfrozen, resuming live playback')
 
 	-- Kill notes when unfreezing buffer to prevent stuck notes from frozen playback
 	if was_frozen and App.playing then self:kill_notes() end
@@ -304,11 +300,13 @@ function Clip:set_playback_loop(start_tick, length)
 	end
 
 	self.last_frozen_step_index = nil
-	print('Clip: Playback loop set to ' .. start_tick .. '-' .. new_end)
+	if flags.debug_clip then
+		print('Clip: Playback loop set to ' .. start_tick .. '-' .. new_end)
+	end
 end
 
 -- Execute pending sync actions (should be called on each clock tick)
-function Clip:execute_sync_actions() self.sync_action_queue:execute_actions() end
+function Clip:execute_sync_actions() self.sync_manager:execute_all() end
 
 -- Transport Event Handling
 function Clip:transport_event(data)
@@ -355,19 +353,8 @@ function Clip:transport_event(data)
 		self.track:update_monitor_state()
 	elseif data.type == 'clock' and App.playing then
 		-- Execute any pending sync actions that have reached their boundary
+		-- SyncManager handles all sync slots: scrub, clip, general, etc.
 		self:execute_sync_actions()
-		-- Also execute ClipGrid's custom sync queue if it exists
-		if self._clipgrid_sync_queue then
-			self._clipgrid_sync_queue:execute_actions()
-			-- Clear the queue if it has no pending actions
-			if not self._clipgrid_sync_queue.pending_action then self._clipgrid_sync_queue = nil end
-		end
-		-- Execute scrub sync queue if it exists (uses scrub_length for sync quantization)
-		if self.scrub_sync_queue then
-			self.scrub_sync_queue:execute_actions()
-			-- Clear the queue if scrub is no longer active and no pending actions
-			if not self.scrub_mode and not self.scrub_sync_queue.pending_action then self.scrub_sync_queue = nil end
-		end
 
 		-- Ensure tick is within loop bounds (safety check for normal playback)
 		-- This handles cases where loop points changed during playback or tick got out of sync
@@ -468,8 +455,8 @@ function Clip:transport_event(data)
 		else
 			-- Incrementally update frozen_buffer if not frozen (for live buffer playback)
 			if not self.scrub_mode and not self.buffer_frozen and self.buffer and self.playback_start and self.playback_length then
-				local step_size = 8 -- Hardcoded step size for incremental updates
-				local current_step_index = math.floor((self.buffer.tick - self.playback_start) / step_size) + 1
+				local step_size = TimingConstants.DEFAULT_STEP_SIZE
+				local current_step_index = TimingConstants.tick_to_buffer_step(self.buffer.tick, self.playback_start, step_size)
 				if self.last_frozen_step_index and current_step_index ~= self.last_frozen_step_index then self:update_frozen_step(self.last_frozen_step_index) end
 				self.last_frozen_step_index = current_step_index
 			end
@@ -629,11 +616,8 @@ function Clip:stop_scrub()
 	self.scrub_length = nil
 	self.scrub_tick = nil
 
-	-- Clear scrub sync queue when scrub stops
-	if self.scrub_sync_queue then
-		self.scrub_sync_queue:clear_action()
-		self.scrub_sync_queue = nil
-	end
+	-- Clear any pending scrub action
+	self.sync_manager:clear('scrub')
 
 	-- Restore input monitoring
 	self.track:update_monitor_state()

--- a/src/lib/utilities/event_store.lua
+++ b/src/lib/utilities/event_store.lua
@@ -1,0 +1,459 @@
+-- ============================================================================
+-- SEQUENTIAL INDEX EVENT STORAGE
+-- Optimized for: insert, delete, range queries on sparse tick-based events
+--
+-- All ticks are 1-based (Lua convention):
+--   - First clock event = tick 1
+--   - Events stored at tick positions within buffer boundaries
+--
+-- Events at each tick are stored as arrays (multiple events per tick supported)
+-- ============================================================================
+
+local EventStore = {}
+EventStore.__index = EventStore
+
+function EventStore.new()
+	local self = setmetatable({}, EventStore)
+	self.events = {} -- sparse table: events[tick] = {event1, event2, ...}
+	self.ticks = {} -- sorted sequential array of tick indices
+	return self
+end
+
+-- ============================================================================
+-- BINARY SEARCH UTILITIES
+-- ============================================================================
+
+-- Find exact match or insertion position
+-- Returns: index (if found), insert_pos (for insertion)
+function EventStore:_binary_search(tick)
+	local ticks = self.ticks
+	local len = #ticks
+
+	if len == 0 then return nil, 1 end -- empty, insert at position 1
+
+	local low, high = 1, len
+
+	while low <= high do
+		local mid = math.floor((low + high) / 2)
+		local mid_val = ticks[mid]
+
+		if mid_val == tick then
+			return mid, mid -- exact match
+		elseif mid_val < tick then
+			low = mid + 1
+		else
+			high = mid - 1
+		end
+	end
+
+	return nil, low -- not found, return insert position
+end
+
+-- Find first tick >= target (for range start)
+function EventStore:_binary_search_ge(tick)
+	local ticks = self.ticks
+	local len = #ticks
+
+	if len == 0 or ticks[len] < tick then return nil end -- no ticks >= target
+
+	local low, high = 1, len
+	local result = nil
+
+	while low <= high do
+		local mid = math.floor((low + high) / 2)
+
+		if ticks[mid] >= tick then
+			result = mid
+			high = mid - 1 -- keep searching left
+		else
+			low = mid + 1
+		end
+	end
+
+	return result
+end
+
+-- ============================================================================
+-- INSERT
+-- Time: O(log n) search + O(n) worst-case insert (if not exists)
+-- Time: O(1) if tick already exists (append to existing array)
+-- ============================================================================
+
+-- Insert a single event at a tick
+-- @param tick number The tick position (1-based)
+-- @param event table The event data to store
+function EventStore:insert(tick, event)
+	local idx, insert_pos = self:_binary_search(tick)
+
+	if idx then
+		-- Tick already exists - append to event array
+		table.insert(self.events[tick], event)
+	else
+		-- New tick - insert into sorted position
+		table.insert(self.ticks, insert_pos, tick)
+		self.events[tick] = { event }
+	end
+end
+
+-- Insert multiple events at a tick (replaces existing events)
+-- @param tick number The tick position (1-based)
+-- @param events table Array of events to store
+function EventStore:set(tick, events)
+	local idx, insert_pos = self:_binary_search(tick)
+
+	if idx then
+		-- Tick already exists - replace event array
+		self.events[tick] = events
+	else
+		-- New tick - insert into sorted position
+		table.insert(self.ticks, insert_pos, tick)
+		self.events[tick] = events
+	end
+end
+
+-- Batch insert (more efficient for multiple events)
+-- @param events_array table Array of {tick=number, event=table} or {tick=number, events=table[]}
+function EventStore:batch_insert(events_array)
+	-- Sort input by tick
+	table.sort(events_array, function(a, b) return a.tick < b.tick end)
+
+	-- Merge sorted arrays
+	local new_ticks = {}
+	local i, j = 1, 1
+	local old_ticks = self.ticks
+
+	while i <= #old_ticks or j <= #events_array do
+		if i > #old_ticks then
+			-- Append remaining new events
+			local ev = events_array[j]
+			table.insert(new_ticks, ev.tick)
+			if ev.events then
+				self.events[ev.tick] = ev.events
+			else
+				self.events[ev.tick] = { ev.event }
+			end
+			j = j + 1
+		elseif j > #events_array then
+			-- Append remaining old ticks
+			table.insert(new_ticks, old_ticks[i])
+			i = i + 1
+		else
+			local old_tick = old_ticks[i]
+			local new_event = events_array[j]
+
+			if old_tick < new_event.tick then
+				table.insert(new_ticks, old_tick)
+				i = i + 1
+			elseif old_tick > new_event.tick then
+				table.insert(new_ticks, new_event.tick)
+				if new_event.events then
+					self.events[new_event.tick] = new_event.events
+				else
+					self.events[new_event.tick] = { new_event.event }
+				end
+				j = j + 1
+			else
+				-- Same tick - merge or replace
+				table.insert(new_ticks, old_tick)
+				if new_event.events then
+					self.events[old_tick] = new_event.events
+				else
+					table.insert(self.events[old_tick], new_event.event)
+				end
+				i = i + 1
+				j = j + 1
+			end
+		end
+	end
+
+	self.ticks = new_ticks
+end
+
+-- ============================================================================
+-- DELETE
+-- Time: O(log n) search + O(n) worst-case removal
+-- ============================================================================
+
+-- Delete all events at a specific tick
+-- @param tick number The tick position
+-- @return boolean True if tick existed and was deleted
+function EventStore:delete(tick)
+	local idx = self:_binary_search(tick)
+
+	if not idx then return false end -- tick doesn't exist
+
+	-- Remove from both structures
+	table.remove(self.ticks, idx)
+	self.events[tick] = nil
+
+	return true
+end
+
+-- Delete range [start_tick, end_tick) (end_tick exclusive)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return number Count of ticks deleted
+function EventStore:delete_range(start_tick, end_tick)
+	local start_idx = self:_binary_search_ge(start_tick)
+
+	if not start_idx then return 0 end -- no events in range
+
+	local count = 0
+	local ticks = self.ticks
+
+	-- Collect indices to remove (backwards to avoid index shifting issues)
+	local to_remove = {}
+
+	for i = start_idx, #ticks do
+		local tick = ticks[i]
+		if tick >= end_tick then break end
+		table.insert(to_remove, 1, i) -- insert at front for reverse order
+		self.events[tick] = nil
+		count = count + 1
+	end
+
+	-- Remove from ticks array (in reverse order)
+	for _, idx in ipairs(to_remove) do
+		table.remove(ticks, idx)
+	end
+
+	return count
+end
+
+-- Delete range [start_tick, end_tick] (both inclusive)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (inclusive)
+-- @return number Count of ticks deleted
+function EventStore:delete_range_inclusive(start_tick, end_tick) return self:delete_range(start_tick, end_tick + 1) end
+
+-- ============================================================================
+-- RANGE QUERIES
+-- Time: O(log n) search + O(m) where m = events in range
+-- ============================================================================
+
+-- Get shallow copy of events in range [start_tick, end_tick)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return table Sparse table of tick -> events
+function EventStore:get_range(start_tick, end_tick)
+	local start_idx = self:_binary_search_ge(start_tick)
+
+	if not start_idx then return {} end -- no events >= start_tick
+
+	local result = {}
+	local ticks = self.ticks
+
+	for i = start_idx, #ticks do
+		local tick = ticks[i]
+		if tick >= end_tick then break end
+		result[tick] = self.events[tick]
+	end
+
+	return result
+end
+
+-- Get events as sorted array (useful for iteration)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return table Array of {tick=number, events=table}
+function EventStore:get_range_array(start_tick, end_tick)
+	local start_idx = self:_binary_search_ge(start_tick)
+
+	if not start_idx then return {} end
+
+	local result = {}
+	local ticks = self.ticks
+
+	for i = start_idx, #ticks do
+		local tick = ticks[i]
+		if tick >= end_tick then break end
+		table.insert(result, { tick = tick, events = self.events[tick] })
+	end
+
+	return result
+end
+
+-- Iterator for range (memory efficient - no copy)
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @return function Iterator returning tick, events
+function EventStore:iter_range(start_tick, end_tick)
+	local start_idx = self:_binary_search_ge(start_tick)
+
+	if not start_idx then
+		return function() return nil end -- empty iterator
+	end
+
+	local ticks = self.ticks
+	local i = start_idx - 1
+	local len = #ticks
+
+	return function()
+		i = i + 1
+		if i > len then return nil end
+
+		local tick = ticks[i]
+		if tick >= end_tick then return nil end
+
+		return tick, self.events[tick]
+	end
+end
+
+-- ============================================================================
+-- UTILITY METHODS
+-- ============================================================================
+
+-- Get events at specific tick
+-- @param tick number The tick position
+-- @return table|nil Array of events or nil if no events
+function EventStore:get(tick) return self.events[tick] end
+
+-- Check if tick has events
+-- @param tick number The tick position
+-- @return boolean True if events exist at tick
+function EventStore:has(tick) return self.events[tick] ~= nil end
+
+-- Get total count of ticks with events
+-- @return number Count of ticks
+function EventStore:count() return #self.ticks end
+
+-- Get total count of events across all ticks
+-- @return number Total event count
+function EventStore:event_count()
+	local count = 0
+	for _, events in pairs(self.events) do
+		count = count + #events
+	end
+	return count
+end
+
+-- Get all ticks (copy)
+-- @return table Array of tick positions
+function EventStore:get_all_ticks()
+	local result = {}
+	for i, tick in ipairs(self.ticks) do
+		result[i] = tick
+	end
+	return result
+end
+
+-- Clear all events
+function EventStore:clear()
+	self.events = {}
+	self.ticks = {}
+end
+
+-- Get earliest tick
+-- @return number|nil First tick or nil if empty
+function EventStore:first_tick() return self.ticks[1] end
+
+-- Get latest tick
+-- @return number|nil Last tick or nil if empty
+function EventStore:last_tick() return self.ticks[#self.ticks] end
+
+-- ============================================================================
+-- COPY OPERATIONS
+-- ============================================================================
+
+-- Create a shallow copy of the store
+-- @return EventStore New store with same events (shared references)
+function EventStore:shallow_copy()
+	local copy = EventStore.new()
+	for i, tick in ipairs(self.ticks) do
+		copy.ticks[i] = tick
+		copy.events[tick] = self.events[tick] -- shallow: same event references
+	end
+	return copy
+end
+
+-- Create a shallow copy of a range
+-- @param start_tick number Start of range (inclusive)
+-- @param end_tick number End of range (exclusive)
+-- @param tick_offset number Optional offset to apply to ticks in copy (default 0)
+-- @return EventStore New store with events from range
+function EventStore:copy_range(start_tick, end_tick, tick_offset)
+	tick_offset = tick_offset or 0
+	local copy = EventStore.new()
+
+	local start_idx = self:_binary_search_ge(start_tick)
+	if not start_idx then return copy end
+
+	for i = start_idx, #self.ticks do
+		local tick = self.ticks[i]
+		if tick >= end_tick then break end
+
+		local new_tick = tick + tick_offset
+		table.insert(copy.ticks, new_tick)
+		copy.events[new_tick] = self.events[tick] -- shallow copy
+	end
+
+	return copy
+end
+
+-- ============================================================================
+-- SPARSE TABLE COMPATIBILITY
+-- For backward compatibility with existing buffer[tick] = events usage
+-- ============================================================================
+
+-- Import from a sparse table (buffer[tick] = events)
+-- @param sparse_table table Sparse table with tick keys
+function EventStore:from_sparse_table(sparse_table)
+	self:clear()
+
+	-- Collect all ticks
+	local ticks = {}
+	for tick, _ in pairs(sparse_table) do
+		table.insert(ticks, tick)
+	end
+
+	-- Sort ticks
+	table.sort(ticks)
+
+	-- Build index
+	self.ticks = ticks
+	for _, tick in ipairs(ticks) do
+		self.events[tick] = sparse_table[tick]
+	end
+end
+
+-- Export to a sparse table (for backward compatibility)
+-- @return table Sparse table with tick keys
+function EventStore:to_sparse_table()
+	local result = {}
+	for tick, events in pairs(self.events) do
+		result[tick] = events
+	end
+	return result
+end
+
+-- ============================================================================
+-- BAR-BASED HELPERS (for convenience)
+-- ============================================================================
+
+-- Get events in bar range
+-- @param bar_start number Start bar (0-based)
+-- @param bar_end number End bar (exclusive)
+-- @param ppqn number Pulses per quarter note (default App.ppqn or 96)
+-- @return table Sparse table of tick -> events
+function EventStore:get_bar_range(bar_start, bar_end, ppqn)
+	ppqn = ppqn or (App and App.ppqn) or 96
+	local ticks_per_bar = ppqn * 4
+	local start_tick = bar_start * ticks_per_bar + 1 -- 1-based
+	local end_tick = bar_end * ticks_per_bar + 1
+	return self:get_range(start_tick, end_tick)
+end
+
+-- Delete events in bar range
+-- @param bar_start number Start bar (0-based)
+-- @param bar_end number End bar (exclusive)
+-- @param ppqn number Pulses per quarter note (default App.ppqn or 96)
+-- @return number Count of ticks deleted
+function EventStore:delete_bar_range(bar_start, bar_end, ppqn)
+	ppqn = ppqn or (App and App.ppqn) or 96
+	local ticks_per_bar = ppqn * 4
+	local start_tick = bar_start * ticks_per_bar + 1 -- 1-based
+	local end_tick = bar_end * ticks_per_bar + 1
+	return self:delete_range(start_tick, end_tick)
+end
+
+return EventStore

--- a/src/lib/utilities/flags.lua
+++ b/src/lib/utilities/flags.lua
@@ -87,6 +87,9 @@ local feature_flag_values = {
 	unit_test = false,
 	verbose = false,
 	buffer_timing_stats = false, -- Enable buffer timing statistics collection
+	debug_clip = false, -- Enable clip component debug logging
+	debug_sync = false, -- Enable sync queue debug logging
+	debug_scrub = false, -- Enable scrub mode debug logging
 }
 
 -- Application runtime state flags (mutated by the app itself)

--- a/src/lib/utilities/sequence_utils.lua
+++ b/src/lib/utilities/sequence_utils.lua
@@ -2,6 +2,8 @@
 -- Shared library for tick/step conversions, sync boundaries, and sync actions
 -- Used by Auto, Buffer, and Clip components for consistent sequence handling
 
+local flags = require('Foobar/lib/utilities/flags')
+
 local SequenceUtils = {}
 
 --==============================================================================
@@ -156,10 +158,12 @@ function SequenceUtils.create_sync_action_queue(component, get_sync_length_fn)
 		local current_tick = App.tick or 1 -- 1-based: first clock = tick 1
 		local next_sync_tick = SequenceUtils.get_next_sync_tick(sync_length, current_tick)
 
-		print('SequenceUtils: Queue action')
-		print('  Current App.tick: ' .. current_tick)
-		print('  Sync length: ' .. sync_length .. ', boundary: ' .. sync_length)
-		print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+		if flags.debug_sync then
+			print('SequenceUtils: Queue action')
+			print('  Current App.tick: ' .. current_tick)
+			print('  Sync length: ' .. sync_length .. ', boundary: ' .. sync_length)
+			print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+		end
 
 		self.pending_action = {
 			action_fn = action_fn,
@@ -169,7 +173,9 @@ function SequenceUtils.create_sync_action_queue(component, get_sync_length_fn)
 
 		-- If we're already at the sync boundary, execute immediately
 		if not SequenceUtils.should_wait_for_sync(sync_length, current_tick) then
-			print('SequenceUtils: Already on sync boundary, executing immediately')
+			if flags.debug_sync then
+				print('SequenceUtils: Already on sync boundary, executing immediately')
+			end
 			self:execute_actions()
 		end
 	end
@@ -186,7 +192,9 @@ function SequenceUtils.create_sync_action_queue(component, get_sync_length_fn)
 
 		local current_tick = App.tick or 1 -- 1-based: first clock = tick 1
 		if current_tick >= self.pending_action.sync_tick then
-			print('SequenceUtils: Execute action at App.tick: ' .. current_tick .. ' (target was: ' .. self.pending_action.sync_tick .. ')')
+			if flags.debug_sync then
+				print('SequenceUtils: Execute action at App.tick: ' .. current_tick .. ' (target was: ' .. self.pending_action.sync_tick .. ')')
+			end
 			-- Execute the action
 			self.pending_action.action_fn(self.component, self.pending_action.action_data)
 

--- a/src/lib/utilities/sync_manager.lua
+++ b/src/lib/utilities/sync_manager.lua
@@ -1,0 +1,216 @@
+-- ============================================================================
+-- SYNC MANAGER
+-- Consolidates multiple sync action queues into a single manager with named slots
+--
+-- Replaces the multiple separate sync queues (sync_action_queue, scrub_sync_queue,
+-- _clipgrid_sync_queue) with a unified interface.
+--
+-- All ticks are 1-based (Lua convention):
+--   - First clock event = tick 1
+--   - Sync boundaries align with tick multiples
+-- ============================================================================
+
+local flags = require('Foobar/lib/utilities/flags')
+local SequenceUtils = require('Foobar/lib/utilities/sequence_utils')
+
+local SyncManager = {}
+SyncManager.__index = SyncManager
+
+-- Create a new SyncManager
+-- @param component table The component this manager belongs to
+-- @param default_sync_length_fn function Optional function to get default sync length: (component) -> number
+-- @return SyncManager
+function SyncManager.new(component, default_sync_length_fn)
+	local self = setmetatable({}, SyncManager)
+	self.component = component
+	self.default_sync_length_fn = default_sync_length_fn or function(c)
+		-- Default: try to get from buffer, fall back to 1 bar
+		if c.buffer and c.buffer.action_sync_length then
+			return c.buffer.action_sync_length
+		elseif c.action_sync_length then
+			return c.action_sync_length
+		else
+			return (App and App.ppqn or 96) * 4 -- 1 bar default
+		end
+	end
+	self.slots = {} -- Named action slots
+	return self
+end
+
+-- ============================================================================
+-- SYNC BOUNDARY CALCULATIONS
+-- ============================================================================
+
+-- Get the next sync boundary tick
+-- @param sync_length number Sync length in ticks
+-- @param current_tick number Current tick (defaults to App.tick)
+-- @return number Next sync boundary tick
+function SyncManager:get_next_sync_tick(sync_length, current_tick)
+	current_tick = current_tick or (App and App.tick) or 1
+	return SequenceUtils.get_next_sync_tick(sync_length, current_tick)
+end
+
+-- Check if we should wait for sync
+-- @param sync_length number Sync length in ticks (0 = disabled)
+-- @param current_tick number Current tick (defaults to App.tick)
+-- @return boolean True if we should wait
+function SyncManager:should_wait_for_sync(sync_length, current_tick)
+	return SequenceUtils.should_wait_for_sync(sync_length, current_tick)
+end
+
+-- ============================================================================
+-- ACTION QUEUE MANAGEMENT
+-- ============================================================================
+
+-- Queue an action in a named slot
+-- Replaces any existing action in that slot
+-- @param slot_name string Name of the slot (e.g., 'scrub', 'clip_load', 'recording')
+-- @param action_fn function Function to execute: (component, action_data) -> void
+-- @param action_data table|nil Optional data to pass to action_fn
+-- @param sync_length number|nil Sync length in ticks (uses default if nil)
+function SyncManager:queue(slot_name, action_fn, action_data, sync_length)
+	sync_length = sync_length or self.default_sync_length_fn(self.component)
+	local current_tick = (App and App.tick) or 1
+	local next_sync_tick = self:get_next_sync_tick(sync_length, current_tick)
+
+	if flags.debug_sync then
+		print('SyncManager: Queue action in slot "' .. slot_name .. '"')
+		print('  Current App.tick: ' .. current_tick)
+		print('  Sync length: ' .. sync_length)
+		print('  Next sync tick: ' .. next_sync_tick .. ' (in ' .. (next_sync_tick - current_tick) .. ' ticks)')
+	end
+
+	self.slots[slot_name] = {
+		action_fn = action_fn,
+		action_data = action_data,
+		sync_tick = next_sync_tick,
+		sync_length = sync_length,
+	}
+
+	-- If already at sync boundary, execute immediately
+	if not self:should_wait_for_sync(sync_length, current_tick) then
+		if flags.debug_sync then
+			print('SyncManager: Already on sync boundary, executing "' .. slot_name .. '" immediately')
+		end
+		self:execute_slot(slot_name)
+	end
+end
+
+-- Queue an action that executes immediately (no sync)
+-- @param slot_name string Name of the slot
+-- @param action_fn function Function to execute
+-- @param action_data table|nil Optional data
+function SyncManager:queue_immediate(slot_name, action_fn, action_data)
+	self.slots[slot_name] = {
+		action_fn = action_fn,
+		action_data = action_data,
+		sync_tick = (App and App.tick) or 1,
+		sync_length = 0,
+	}
+	self:execute_slot(slot_name)
+end
+
+-- Clear a specific slot
+-- @param slot_name string Name of the slot to clear
+function SyncManager:clear(slot_name) self.slots[slot_name] = nil end
+
+-- Clear all slots
+function SyncManager:clear_all() self.slots = {} end
+
+-- Check if a slot has a pending action
+-- @param slot_name string Name of the slot
+-- @return boolean True if action is pending
+function SyncManager:has_pending(slot_name) return self.slots[slot_name] ~= nil end
+
+-- Get pending action info for a slot
+-- @param slot_name string Name of the slot
+-- @return table|nil Action info or nil
+function SyncManager:get_pending(slot_name) return self.slots[slot_name] end
+
+-- ============================================================================
+-- EXECUTION
+-- ============================================================================
+
+-- Execute a specific slot if its sync tick has been reached
+-- @param slot_name string Name of the slot
+-- @return boolean True if action was executed
+function SyncManager:execute_slot(slot_name)
+	local slot = self.slots[slot_name]
+	if not slot then return false end
+
+	local current_tick = (App and App.tick) or 1
+	if current_tick >= slot.sync_tick then
+		if flags.debug_sync then
+			print('SyncManager: Execute "' .. slot_name .. '" at App.tick: ' .. current_tick .. ' (target was: ' .. slot.sync_tick .. ')')
+		end
+
+		-- Execute the action
+		slot.action_fn(self.component, slot.action_data)
+
+		-- Clear the slot
+		self.slots[slot_name] = nil
+		return true
+	end
+
+	return false
+end
+
+-- Execute all slots that have reached their sync tick
+-- Should be called on each clock tick
+-- @return number Count of actions executed
+function SyncManager:execute_all()
+	local current_tick = (App and App.tick) or 1
+	local executed_count = 0
+
+	-- Collect slots to execute (to avoid modifying while iterating)
+	local to_execute = {}
+	for slot_name, slot in pairs(self.slots) do
+		if current_tick >= slot.sync_tick then table.insert(to_execute, slot_name) end
+	end
+
+	-- Execute collected slots
+	for _, slot_name in ipairs(to_execute) do
+		local slot = self.slots[slot_name]
+		if slot then
+			if flags.debug_sync then
+				print('SyncManager: Execute "' .. slot_name .. '" at App.tick: ' .. current_tick .. ' (target was: ' .. slot.sync_tick .. ')')
+			end
+
+			slot.action_fn(self.component, slot.action_data)
+			self.slots[slot_name] = nil
+			executed_count = executed_count + 1
+		end
+	end
+
+	return executed_count
+end
+
+-- ============================================================================
+-- UTILITY METHODS
+-- ============================================================================
+
+-- Get list of all pending slot names
+-- @return table Array of slot names
+function SyncManager:get_pending_slots()
+	local names = {}
+	for name, _ in pairs(self.slots) do
+		table.insert(names, name)
+	end
+	return names
+end
+
+-- Get count of pending actions
+-- @return number Count
+function SyncManager:pending_count()
+	local count = 0
+	for _, _ in pairs(self.slots) do
+		count = count + 1
+	end
+	return count
+end
+
+-- Check if any actions are pending
+-- @return boolean True if any actions pending
+function SyncManager:has_any_pending() return next(self.slots) ~= nil end
+
+return SyncManager

--- a/src/lib/utilities/timing_constants.lua
+++ b/src/lib/utilities/timing_constants.lua
@@ -1,0 +1,88 @@
+-- Timing Constants
+-- Centralized timing values for buffer, clip, and sequencer operations
+-- All tick calculations use 1-based indexing (Lua convention):
+--   - First clock event = tick 1
+--   - First step (at default step_size) = ticks 1 to step_size
+--   - Step index formula: floor((tick - 1) / step_size) + 1
+
+local TimingConstants = {}
+
+-- Step size for buffer overwrite clearing and incremental frozen buffer updates
+-- Events are grouped into steps of this many ticks
+-- Used in: buffer.lua (overwrite clearing), clip.lua (frozen buffer updates)
+TimingConstants.DEFAULT_STEP_SIZE = 8
+
+-- Default buffer length in bars (for new buffers)
+TimingConstants.DEFAULT_BUFFER_BARS = 64
+
+-- Calculate buffer length in ticks from bars
+-- @param bars number Number of bars
+-- @param ppqn number Pulses per quarter note (defaults to App.ppqn or 96)
+-- @return number Length in ticks
+function TimingConstants.bars_to_ticks(bars, ppqn)
+	ppqn = ppqn or (App and App.ppqn) or 96
+	local ticks_per_bar = ppqn * 4 -- 4 beats per bar
+	return bars * ticks_per_bar
+end
+
+-- Calculate default buffer length in ticks
+-- @param ppqn number Pulses per quarter note (defaults to App.ppqn or 96)
+-- @return number Default buffer length in ticks
+function TimingConstants.get_default_buffer_length(ppqn)
+	return TimingConstants.bars_to_ticks(TimingConstants.DEFAULT_BUFFER_BARS, ppqn)
+end
+
+-- Convert tick to step index (1-based)
+-- Step 1 = ticks 1 to step_size, Step 2 = ticks step_size+1 to 2*step_size, etc.
+-- @param tick number Tick position (1-based)
+-- @param step_size number Step length in ticks (defaults to DEFAULT_STEP_SIZE)
+-- @return number Step index (1-based)
+function TimingConstants.tick_to_step(tick, step_size)
+	step_size = step_size or TimingConstants.DEFAULT_STEP_SIZE
+	return math.floor((tick - 1) / step_size) + 1
+end
+
+-- Convert step index to tick range (returns start_tick, end_tick inclusive)
+-- @param step_index number Step index (1-based)
+-- @param step_size number Step length in ticks (defaults to DEFAULT_STEP_SIZE)
+-- @return number, number start_tick, end_tick (both 1-based, inclusive)
+function TimingConstants.step_to_tick_range(step_index, step_size)
+	step_size = step_size or TimingConstants.DEFAULT_STEP_SIZE
+	local start_tick = (step_index - 1) * step_size + 1
+	local end_tick = step_index * step_size
+	return start_tick, end_tick
+end
+
+-- Convert step index to start tick (1-based)
+-- @param step_index number Step index (1-based)
+-- @param step_size number Step length in ticks (defaults to DEFAULT_STEP_SIZE)
+-- @return number Start tick of the step (1-based)
+function TimingConstants.step_to_start_tick(step_index, step_size)
+	step_size = step_size or TimingConstants.DEFAULT_STEP_SIZE
+	return (step_index - 1) * step_size + 1
+end
+
+-- Calculate step index relative to a buffer start position
+-- @param tick number Current tick position
+-- @param buffer_start number Buffer start tick
+-- @param step_size number Step length in ticks (defaults to DEFAULT_STEP_SIZE)
+-- @return number Step index (1-based) relative to buffer start
+function TimingConstants.tick_to_buffer_step(tick, buffer_start, step_size)
+	step_size = step_size or TimingConstants.DEFAULT_STEP_SIZE
+	return math.floor((tick - buffer_start) / step_size) + 1
+end
+
+-- Calculate step tick range relative to a buffer
+-- @param step_index number Step index (1-based) relative to buffer start
+-- @param buffer_start number Buffer start tick
+-- @param buffer_end number Buffer end tick (for clamping)
+-- @param step_size number Step length in ticks (defaults to DEFAULT_STEP_SIZE)
+-- @return number, number start_tick, end_tick (clamped to buffer bounds)
+function TimingConstants.buffer_step_to_tick_range(step_index, buffer_start, buffer_end, step_size)
+	step_size = step_size or TimingConstants.DEFAULT_STEP_SIZE
+	local step_start = buffer_start + (step_index - 1) * step_size
+	local step_end = math.min(step_start + step_size - 1, buffer_end)
+	return step_start, step_end
+end
+
+return TimingConstants


### PR DESCRIPTION
## Summary
This PR refactors the synchronization system to use a unified `SyncManager` instead of multiple ad-hoc sync queues, and adds conditional debug logging via feature flags for better observability and performance.

## Key Changes

### Sync Management Refactoring
- **Unified SyncManager**: Replaces multiple sync queue implementations (`sync_action_queue`, `scrub_sync_queue`, `_clipgrid_sync_queue`) with a single `SyncManager` that handles named slots ('scrub', 'clip', 'clipgrid_recording', 'clipgrid_playback', etc.)
- **Simplified API**: Reduces complexity by consolidating queue creation, action queueing, and execution into a single interface
- **Better slot isolation**: Named slots prevent conflicts between different sync operations (scrub vs clip playback vs recording)

### Debug Logging Improvements
- **Feature flags**: All debug print statements now wrapped in `flags.debug_scrub` and `flags.debug_clip` checks
- **Performance benefit**: Debug logging can be disabled at runtime without code changes
- **Cleaner output**: Removed verbose intermediate calculations from logs; kept only essential information
- **Conditional computation**: Debug-only calculations (like sync tick computations) now only execute when flags are enabled

### EventStore Integration
- **Buffer refactoring**: Migrated from sparse table to `EventStore` for efficient range queries and event management
- **Backward compatibility**: `self.buffer` still points to events table for existing code
- **New query methods**: Added `get_range()`, `iter_range()`, `get_events()`, `has_events()`, etc. for efficient event access
- **Migration support**: Handles migration from old buffer structures

### Timing Constants
- **Centralized constants**: Extracted magic numbers (step_size=8, buffer_length) to `TimingConstants` module
- **Helper functions**: Added `tick_to_buffer_step()` and `buffer_step_to_tick_range()` for consistent step calculations
- **Maintainability**: Single source of truth for timing-related constants

### Code Cleanup
- Removed temporary sync queue workarounds in ClipGrid
- Simplified recording/playback queueing logic
- Reduced print statement verbosity while maintaining diagnostic capability
- Removed unused variables and intermediate calculations

## Implementation Details
- SyncManager maintains a queue per named slot, allowing multiple independent sync operations
- Each slot can have its own sync length (e.g., scrub uses scrub_length, clip uses action_sync_length)
- Debug flags are checked at the point of logging, avoiding unnecessary string concatenation
- EventStore maintains a sorted tick index for O(log n) range queries instead of O(n) iteration

https://claude.ai/code/session_01CYVxn292heMCWSsrAiAHTp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sequencing paths (sync scheduling, buffer recording storage, and playback timing), so regressions could affect quantization, looping, or event retention despite being largely internal refactors.
> 
> **Overview**
> **Refactors sync-quantized actions to use a unified `SyncManager` with named slots** (replacing ad-hoc/per-feature sync queues). `Clip` now owns a `sync_manager` and executes all pending actions via it each clock; `ClipGrid` queues/clears recording, playback, and stop actions through those slots, and scrub actions are queued/cleared through the same mechanism.
> 
> **Improves observability control and reduces noise** by gating most clip/scrub/sync `print()` logging behind new feature flags (`debug_clip`, `debug_scrub`, `debug_sync`) and avoiding debug-only calculations unless enabled.
> 
> **Reworks buffer event storage and timing constants** by introducing `EventStore` (sorted tick index + range query APIs) and migrating `Buffer` to use it for inserts/deletes/clears while keeping `buffer[tick]` compatibility. Adds `TimingConstants` to centralize step size/buffer length defaults and replaces hardcoded step math in `Buffer`/`Clip` with shared helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef85ab080fa61a30778272385100426572344108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->